### PR TITLE
Fixed bug of voucher date filtering

### DIFF
--- a/xml/trn_voucher.xml
+++ b/xml/trn_voucher.xml
@@ -10,8 +10,8 @@
         <DESC>
             <STATICVARIABLES>
                 <SVEXPORTFORMAT>$$SysName:ASCII</SVEXPORTFORMAT>
-                <SVFROMDATE>{fromDate}</SVFROMDATE>
-                <SVTODATE>{toDate}</SVTODATE>
+                <SVFROMDATE TYPE="DATE">{fromDate}</SVFROMDATE>
+                <SVTODATE TYPE="DATE">{toDate}</SVTODATE>
             </STATICVARIABLES>
             <TDL>
                 <TDLMESSAGE>


### PR DESCRIPTION
In tally prime, the date filtering happens only if `type=date` is specified