### PR TITLE
Adding Invoice number details [ name ] Field in mst_opening_bill_allocation

### DIFF
--- a/database-structure.sql
+++ b/database-structure.sql
@@ -163,7 +163,8 @@ create table mst_opening_bill_allocation
  ledger nvarchar(1024) not null default '',
  _ledger varchar(64) not null default '',
  opening_balance decimal(17,4) default 0,
- bill_date date
+ bill_date date,
+ name nvarchar(1024) not null default ''
 );
 
 create table trn_closingstock_ledger

--- a/tally-export-config.yaml
+++ b/tally-export-config.yaml
@@ -450,6 +450,9 @@ master:
         - name: bill_date
           field: BillDate
           type: date
+        - name: name
+          field: Name
+          type: text
     - name: trn_closingstock_ledger
       collection: Ledger.LedgerClosingValues
       nature: Derived


### PR DESCRIPTION
Presently the table [ mst_opening_bill_allocation ] shows amount and date of opening transactions.
There are chances that some out the Invoices in previous financial year remains unpaid in next period. In such case you need to tract INVOICE Number wise & DATE wise details from previous Financial Year or Period you have selected in the utility.

But presently the utility pulls only DATE but not INVOICE number of such transactions.
Hence updated the utility to add Invoice Number / Document details in Mst Opening Bills.
I find this field is useful for tracing payment outstanding with BILL No Wise details & can be used further in other queries.

Accordingly updated **tally-export-config.yaml** & **database-structure.sql** to reflect the same change.

CAUTION - 
**This adds a new Field Name called [ name ] in table named [ mst_opening_bill_allocation ]**
It is a structural change and if you are already using imported data in database like mysql or mariadb, you need to issue following database command to insert [ name ] after bill_date 

---------------------------------------------------
```
ALTER TABLE mst_opening_bill_allocation
ADD COLUMN name nvarchar(1024)
AFTER bill_date;
```
----------------------------------------------------

**ELSE you can rebuild table structure [ mst_opening_bill_allocation ] by first dropping it then by recreating it**

---------------------------------------------------
```
DROP TABLE mst_opening_bill_allocation;

CREATE TABLE mst_opening_bill_allocation
(
 ledger nvarchar(1024) not null default '',
 _ledger varchar(64) not null default '',
 opening_balance decimal(17,4) default 0,
 bill_date date,
 name nvarchar(1024) not null default ''
);
```
---------------------------------------------------

**Then ensure to run the utility again to populate data in database !**

---------------------------------------------------
