### PR TITLE
Fix default GST rate value in export config

### DIFF
--- a/tally-export-config.yaml
+++ b/tally-export-config.yaml
@@ -264,7 +264,7 @@ master:
           field: InfGSTHSNDescription
           type: text
         - name: gst_rate
-          field: if $$IsEmpty:$InfGSTIGSTRate then "0" else $InfGSTIGSTRate
+          field: InfGSTIGSTRate
           type: number
         - name: gst_taxability
           field: InfGSTTaxablility

--- a/tally-export-config.yaml
+++ b/tally-export-config.yaml
@@ -264,7 +264,7 @@ master:
           field: InfGSTHSNDescription
           type: text
         - name: gst_rate
-          field: if $$IsEmpty:InfGSTIGSTRate then "" else $InfGSTIGSTRate
+          field: if $$IsEmpty:$InfGSTIGSTRate then "0" else $InfGSTIGSTRate
           type: number
         - name: gst_taxability
           field: InfGSTTaxablility


### PR DESCRIPTION
Updated the `gst_rate` field to use "0" as the default value instead of an empty string when the `InfGSTIGSTRate` field is empty.

This will fix this issue - https://github.com/dhananjay1405/tally-database-loader/issues/39