### PR TITLE
fix: Add numeric field validation to handle invalid formats like (-)5

### DIFF
--- a/dist/database.mjs
+++ b/dist/database.mjs
@@ -319,6 +319,29 @@ class _database {
                                 else if (targetFieldType == 'date') {
                                     lstValues[i] = targetFieldValue == 'ñ' ? 'NULL' : `'${targetFieldValue}'`;
                                 }
+                                else if (targetFieldType == 'number' || targetFieldType == 'amount' || targetFieldType == 'quantity' || targetFieldType == 'rate' || targetFieldType == 'logical') {
+                                    // Clean up numeric values - handle special cases like (-)5 which means -5
+                                    if (targetFieldValue.match(/^\([-+]\)\d+\.?\d*$/)) {
+                                        // Pattern like (-)5 or (+)5 - extract the sign and number
+                                        let sign = targetFieldValue.includes('-') ? '-' : '';
+                                        let numPart = targetFieldValue.replace(/[()+-]/g, '');
+                                        targetFieldValue = sign + numPart;
+                                    }
+                                    targetFieldValue = targetFieldValue.trim();
+                                    // Check if it's a valid number
+                                    if (targetFieldValue === '' || targetFieldValue === 'ñ') {
+                                        lstValues[i] = 'NULL';
+                                    }
+                                    else {
+                                        let numValue = parseFloat(targetFieldValue);
+                                        if (isNaN(numValue)) {
+                                            lstValues[i] = '0'; // Default to 0 for invalid numbers
+                                        }
+                                        else {
+                                            lstValues[i] = numValue.toString();
+                                        }
+                                    }
+                                }
                                 else
                                     ;
                             }

--- a/src/database.mts
+++ b/src/database.mts
@@ -305,6 +305,27 @@ class _database {
                                 else if (targetFieldType == 'date') {
                                     lstValues[i] = targetFieldValue == 'ñ' ? 'NULL' : `'${targetFieldValue}'`;
                                 }
+                                else if (targetFieldType == 'number' || targetFieldType == 'amount' || targetFieldType == 'quantity' || targetFieldType == 'rate' || targetFieldType == 'logical') {
+                                    // Clean up numeric values - handle special cases like (-)5 which means -5
+                                    if (targetFieldValue.match(/^\([-+]\)\d+\.?\d*$/)) {
+                                        // Pattern like (-)5 or (+)5 - extract the sign and number
+                                        let sign = targetFieldValue.includes('-') ? '-' : '';
+                                        let numPart = targetFieldValue.replace(/[()+-]/g, '');
+                                        targetFieldValue = sign + numPart;
+                                    }
+                                    targetFieldValue = targetFieldValue.trim();
+                                    // Check if it's a valid number
+                                    if (targetFieldValue === '' || targetFieldValue === 'ñ') {
+                                        lstValues[i] = 'NULL';
+                                    } else {
+                                        let numValue = parseFloat(targetFieldValue);
+                                        if (isNaN(numValue)) {
+                                            lstValues[i] = '0'; // Default to 0 for invalid numbers
+                                        } else {
+                                            lstValues[i] = numValue.toString();
+                                        }
+                                    }
+                                }
                                 else;
                             }
                             activeLine = lstValues.join(','); //prepare SQL statement with values separated by comma

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -7,6 +7,7 @@
         "outDir": "../dist",
         "rootDir": "./",
         "strict": true,
-        "sourceMap": true /* Generates corresponding '.map' file. */
+        "sourceMap": true, /* Generates corresponding '.map' file. */
+        "skipLibCheck": true /* Skip type checking of declaration files */
     }
 }


### PR DESCRIPTION
Fix: SQL syntax error from invalid numeric values in Tally exports
Problem
When using INSERT statements for data loading, the application crashes with SQL syntax error:

You have an error in your SQL syntax... near ')5),...'

Root Cause: Tally exports certain numeric values in non-standard format like (-)5 instead of -5. When these values are inserted directly into SQL queries without validation, they cause syntax errors because (-)5 is not valid SQL.

Solution
Added numeric field validation in the bulkLoad function that:

Detects and converts special patterns like (-)5 → -5
Validates all numeric field types (number, amount, quantity, rate, logical)
Handles NULL values properly
Defaults invalid numbers to 0
Changes
database.mts
: Added numeric validation logic
database.mjs
: Compiled output
tsconfig.json
: Added skipLibCheck for build compatibility
Testing
Import completes successfully without SQL errors Numeric values are correctly parsed and inserted Special formats like (-)5 are properly converted